### PR TITLE
[eclipse/xtext#1089] Replace (not)equal operators by triple (not)equals

### DIFF
--- a/org.eclipse.xtext.web.example.entities/src/org/eclipse/xtext/web/example/entities/jvmmodel/EntitiesJvmModelInferrer.xtend
+++ b/org.eclipse.xtext.web.example.entities/src/org/eclipse/xtext/web/example/entities/jvmmodel/EntitiesJvmModelInferrer.xtend
@@ -25,7 +25,7 @@ class EntitiesJvmModelInferrer extends AbstractModelInferrer {
 	def dispatch infer(Entity entity, extension IJvmDeclaredTypeAcceptor acceptor, boolean prelinkingPhase) {
 		accept(entity.toClass( entity.fullyQualifiedName )) [
 			documentation = entity.documentation
-			if (entity.superType != null)
+			if (entity.superType !== null)
 				superTypes += entity.superType.cloneWithProxies
 			
 			// let's add a default constructor

--- a/org.eclipse.xtext.web.example.entities/xtend-gen/org/eclipse/xtext/web/example/entities/jvmmodel/EntitiesJvmModelInferrer.java
+++ b/org.eclipse.xtext.web.example.entities/xtend-gen/org/eclipse/xtext/web/example/entities/jvmmodel/EntitiesJvmModelInferrer.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.web.example.entities.jvmmodel;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Arrays;
 import org.eclipse.emf.common.util.EList;
@@ -51,8 +50,8 @@ public class EntitiesJvmModelInferrer extends AbstractModelInferrer {
       String _documentation = this._jvmTypesBuilder.getDocumentation(entity);
       this._jvmTypesBuilder.setDocumentation(it, _documentation);
       JvmParameterizedTypeReference _superType = entity.getSuperType();
-      boolean _notEquals = (!Objects.equal(_superType, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_superType != null);
+      if (_tripleNotEquals) {
         EList<JvmTypeReference> _superTypes = it.getSuperTypes();
         JvmParameterizedTypeReference _superType_1 = entity.getSuperType();
         JvmTypeReference _cloneWithProxies = this._jvmTypesBuilder.cloneWithProxies(_superType_1);

--- a/org.eclipse.xtext.web.servlet/src/main/java/org/eclipse/xtext/web/servlet/HttpServiceContext.xtend
+++ b/org.eclipse.xtext.web.servlet/src/main/java/org/eclipse/xtext/web/servlet/HttpServiceContext.xtend
@@ -69,7 +69,7 @@ class HttpServiceContext implements IServiceContext {
 	}
 	
 	override getSession() {
-		if (sessionWrapper == null)
+		if (sessionWrapper === null)
 			sessionWrapper = new HttpSessionWrapper(request.getSession(true))
 		return sessionWrapper
 	}

--- a/org.eclipse.xtext.web.servlet/src/main/xtend-gen/org/eclipse/xtext/web/servlet/HttpServiceContext.java
+++ b/org.eclipse.xtext.web.servlet/src/main/xtend-gen/org/eclipse/xtext/web/servlet/HttpServiceContext.java
@@ -119,8 +119,7 @@ public class HttpServiceContext implements IServiceContext {
   
   @Override
   public ISession getSession() {
-    boolean _equals = Objects.equal(this.sessionWrapper, null);
-    if (_equals) {
+    if ((this.sessionWrapper == null)) {
       HttpSession _session = this.request.getSession(true);
       HttpSessionWrapper _httpSessionWrapper = new HttpSessionWrapper(_session);
       this.sessionWrapper = _httpSessionWrapper;

--- a/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/util/ElementAtOffsetUtil.xtend
+++ b/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/util/ElementAtOffsetUtil.xtend
@@ -20,11 +20,11 @@ class ElementAtOffsetUtil {
 
 	def EObject getElementAt(XtextResource resource, int offset) {
 		var crossLinkedEObject = resource.resolveCrossReferencedElementAt(offset)
-		if (crossLinkedEObject != null) {
+		if (crossLinkedEObject !== null) {
 			return crossLinkedEObject
 		} else {
 			var containedEObject = resource.resolveContainedElementAt(offset)
-			if (containedEObject != null) {
+			if (containedEObject !== null) {
 				val nameRegion = containedEObject.significantTextRegion
 				if (nameRegion.contains(offset))
 					return containedEObject

--- a/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/util/ElementAtOffsetUtil.java
+++ b/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/util/ElementAtOffsetUtil.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.web.server.util;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.resource.EObjectAtOffsetHelper;
@@ -28,13 +27,11 @@ public class ElementAtOffsetUtil {
   
   public EObject getElementAt(final XtextResource resource, final int offset) {
     EObject crossLinkedEObject = this._eObjectAtOffsetHelper.resolveCrossReferencedElementAt(resource, offset);
-    boolean _notEquals = (!Objects.equal(crossLinkedEObject, null));
-    if (_notEquals) {
+    if ((crossLinkedEObject != null)) {
       return crossLinkedEObject;
     } else {
       EObject containedEObject = this._eObjectAtOffsetHelper.resolveContainedElementAt(resource, offset);
-      boolean _notEquals_1 = (!Objects.equal(containedEObject, null));
-      if (_notEquals_1) {
+      if ((containedEObject != null)) {
         final ITextRegion nameRegion = this._iLocationInFileProvider.getSignificantTextRegion(containedEObject);
         boolean _contains = nameRegion.contains(offset);
         if (_contains) {


### PR DESCRIPTION
For comparison with null the triple (not) equal operator should be used.
Resolved compiler warnings
