### PR TITLE
[492072] Minimized usage of local variables

### DIFF
--- a/org.eclipse.xtext.web.example.entities/xtend-gen/org/eclipse/xtext/web/example/entities/jvmmodel/EntitiesJvmModelInferrer.java
+++ b/org.eclipse.xtext.web.example.entities/xtend-gen/org/eclipse/xtext/web/example/entities/jvmmodel/EntitiesJvmModelInferrer.java
@@ -21,12 +21,10 @@ import org.eclipse.xtext.common.types.JvmOperation;
 import org.eclipse.xtext.common.types.JvmParameterizedTypeReference;
 import org.eclipse.xtext.common.types.JvmTypeReference;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
-import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.web.example.entities.domainmodel.Entity;
 import org.eclipse.xtext.web.example.entities.domainmodel.Feature;
 import org.eclipse.xtext.web.example.entities.domainmodel.Operation;
 import org.eclipse.xtext.web.example.entities.domainmodel.Property;
-import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.jvmmodel.AbstractModelInferrer;
 import org.eclipse.xtext.xbase.jvmmodel.IJvmDeclaredTypeAcceptor;
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypesBuilder;
@@ -44,11 +42,8 @@ public class EntitiesJvmModelInferrer extends AbstractModelInferrer {
   private IQualifiedNameProvider _iQualifiedNameProvider;
   
   protected void _infer(final Entity entity, @Extension final IJvmDeclaredTypeAcceptor acceptor, final boolean prelinkingPhase) {
-    QualifiedName _fullyQualifiedName = this._iQualifiedNameProvider.getFullyQualifiedName(entity);
-    JvmGenericType _class = this._jvmTypesBuilder.toClass(entity, _fullyQualifiedName);
     final Procedure1<JvmGenericType> _function = (JvmGenericType it) -> {
-      String _documentation = this._jvmTypesBuilder.getDocumentation(entity);
-      this._jvmTypesBuilder.setDocumentation(it, _documentation);
+      this._jvmTypesBuilder.setDocumentation(it, this._jvmTypesBuilder.getDocumentation(entity));
       JvmParameterizedTypeReference _superType = entity.getSuperType();
       boolean _tripleNotEquals = (_superType != null);
       if (_tripleNotEquals) {
@@ -62,8 +57,7 @@ public class EntitiesJvmModelInferrer extends AbstractModelInferrer {
       };
       JvmConstructor _constructor = this._jvmTypesBuilder.toConstructor(entity, _function_1);
       this._jvmTypesBuilder.<JvmConstructor>operator_add(_members, _constructor);
-      JvmTypeReference _typeRef = this._typeReferenceBuilder.typeRef(it);
-      final JvmTypeReference procedureType = this._typeReferenceBuilder.typeRef(Procedure1.class, _typeRef);
+      final JvmTypeReference procedureType = this._typeReferenceBuilder.typeRef(Procedure1.class, this._typeReferenceBuilder.typeRef(it));
       EList<JvmMember> _members_1 = it.getMembers();
       final Procedure1<JvmConstructor> _function_2 = (JvmConstructor it_1) -> {
         EList<JvmFormalParameter> _parameters = it_1.getParameters();
@@ -115,8 +109,7 @@ public class EntitiesJvmModelInferrer extends AbstractModelInferrer {
               _elvis = _inferredType;
             }
             final Procedure1<JvmOperation> _function_3 = (JvmOperation it_1) -> {
-              String _documentation_1 = this._jvmTypesBuilder.getDocumentation(f);
-              this._jvmTypesBuilder.setDocumentation(it_1, _documentation_1);
+              this._jvmTypesBuilder.setDocumentation(it_1, this._jvmTypesBuilder.getDocumentation(f));
               EList<JvmFormalParameter> _params = ((Operation)f).getParams();
               for (final JvmFormalParameter p : _params) {
                 EList<JvmFormalParameter> _parameters = it_1.getParameters();
@@ -125,8 +118,7 @@ public class EntitiesJvmModelInferrer extends AbstractModelInferrer {
                 JvmFormalParameter _parameter = this._jvmTypesBuilder.toParameter(p, _name_1, _parameterType);
                 this._jvmTypesBuilder.<JvmFormalParameter>operator_add(_parameters, _parameter);
               }
-              XExpression _body = ((Operation)f).getBody();
-              this._jvmTypesBuilder.setBody(it_1, _body);
+              this._jvmTypesBuilder.setBody(it_1, ((Operation)f).getBody());
             };
             JvmOperation _method = this._jvmTypesBuilder.toMethod(f, _name, _elvis, _function_3);
             this._jvmTypesBuilder.<JvmOperation>operator_add(_members_2, _method);
@@ -137,7 +129,7 @@ public class EntitiesJvmModelInferrer extends AbstractModelInferrer {
       JvmOperation _toStringMethod = this._jvmTypesBuilder.toToStringMethod(entity, it);
       this._jvmTypesBuilder.<JvmOperation>operator_add(_members_2, _toStringMethod);
     };
-    acceptor.<JvmGenericType>accept(_class, _function);
+    acceptor.<JvmGenericType>accept(this._jvmTypesBuilder.toClass(entity, this._iQualifiedNameProvider.getFullyQualifiedName(entity)), _function);
   }
   
   public void infer(final EObject entity, final IJvmDeclaredTypeAcceptor acceptor, final boolean prelinkingPhase) {

--- a/org.eclipse.xtext.web.example.statemachine.ide/xtend-gen/org/eclipse/xtext/web/example/statemachine/ide/StatemachineSemanticHighlightingCalculator.java
+++ b/org.eclipse.xtext.web.example.statemachine.ide/xtend-gen/org/eclipse/xtext/web/example/statemachine/ide/StatemachineSemanticHighlightingCalculator.java
@@ -41,15 +41,13 @@ public class StatemachineSemanticHighlightingCalculator extends DefaultSemanticH
     if (!_matched) {
       if (it instanceof Command) {
         _matched=true;
-        Signal _signal = ((Command)it).getSignal();
-        this.highlightSignal(it, _signal, StatemachinePackage.Literals.COMMAND__SIGNAL, acceptor, cancelIndicator);
+        this.highlightSignal(it, ((Command)it).getSignal(), StatemachinePackage.Literals.COMMAND__SIGNAL, acceptor, cancelIndicator);
       }
     }
     if (!_matched) {
       if (it instanceof Event) {
         _matched=true;
-        Signal _signal = ((Event)it).getSignal();
-        this.highlightSignal(it, _signal, StatemachinePackage.Literals.EVENT__SIGNAL, acceptor, cancelIndicator);
+        this.highlightSignal(it, ((Event)it).getSignal(), StatemachinePackage.Literals.EVENT__SIGNAL, acceptor, cancelIndicator);
       }
     }
     return false;

--- a/org.eclipse.xtext.web.example.statemachine/xtend-gen/org/eclipse/xtext/web/example/statemachine/formatting2/StatemachineFormatter.java
+++ b/org.eclipse.xtext.web.example.statemachine/xtend-gen/org/eclipse/xtext/web/example/statemachine/formatting2/StatemachineFormatter.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.function.Consumer;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.xtext.Assignment;
 import org.eclipse.xtext.Keyword;
 import org.eclipse.xtext.formatting2.AbstractFormatter2;
 import org.eclipse.xtext.formatting2.IFormattableDocument;
@@ -85,50 +84,42 @@ public class StatemachineFormatter extends AbstractFormatter2 {
       it.oneSpace();
     };
     document.append(_keyword, _function);
-    ISemanticRegionsFinder _regionFor_1 = this.textRegionExtensions.regionFor(state);
-    StatemachineGrammarAccess.StateElements _stateAccess_1 = this._statemachineGrammarAccess.getStateAccess();
-    Assignment _nameAssignment_1 = _stateAccess_1.getNameAssignment_1();
-    ISemanticRegion _assignment = _regionFor_1.assignment(_nameAssignment_1);
     final Procedure1<IHiddenRegionFormatter> _function_1 = (IHiddenRegionFormatter it) -> {
-      it.newLine();
-    };
-    ISemanticRegion _append = document.append(_assignment, _function_1);
-    ISemanticRegionsFinder _regionFor_2 = this.textRegionExtensions.regionFor(state);
-    StatemachineGrammarAccess.StateElements _stateAccess_2 = this._statemachineGrammarAccess.getStateAccess();
-    Keyword _endKeyword_5 = _stateAccess_2.getEndKeyword_5();
-    ISemanticRegion _keyword_1 = _regionFor_2.keyword(_endKeyword_5);
-    final Procedure1<IHiddenRegionFormatter> _function_2 = (IHiddenRegionFormatter it) -> {
       it.indent();
     };
-    document.<ISemanticRegion, ISemanticRegion>interior(_append, _keyword_1, _function_2);
+    document.<ISemanticRegion, ISemanticRegion>interior(
+      document.append(this.textRegionExtensions.regionFor(state).assignment(this._statemachineGrammarAccess.getStateAccess().getNameAssignment_1()), ((Procedure1<IHiddenRegionFormatter>) (IHiddenRegionFormatter it) -> {
+        it.newLine();
+      })), 
+      this.textRegionExtensions.regionFor(state).keyword(this._statemachineGrammarAccess.getStateAccess().getEndKeyword_5()), _function_1);
     EList<Command> _commands = state.getCommands();
     for (final Command command : _commands) {
       {
         this.format(command, document);
-        final Procedure1<IHiddenRegionFormatter> _function_3 = (IHiddenRegionFormatter it) -> {
+        final Procedure1<IHiddenRegionFormatter> _function_2 = (IHiddenRegionFormatter it) -> {
           it.newLine();
         };
-        document.<Command>append(command, _function_3);
+        document.<Command>append(command, _function_2);
       }
     }
     EList<Transition> _transitions = state.getTransitions();
     for (final Transition transition : _transitions) {
       {
         this.format(transition, document);
-        final Procedure1<IHiddenRegionFormatter> _function_3 = (IHiddenRegionFormatter it) -> {
+        final Procedure1<IHiddenRegionFormatter> _function_2 = (IHiddenRegionFormatter it) -> {
           it.newLine();
         };
-        document.<Transition>append(transition, _function_3);
+        document.<Transition>append(transition, _function_2);
       }
     }
     EList<State> _nestedStates = state.getNestedStates();
     for (final State nestedState : _nestedStates) {
       {
         this.format(nestedState, document);
-        final Procedure1<IHiddenRegionFormatter> _function_3 = (IHiddenRegionFormatter it) -> {
+        final Procedure1<IHiddenRegionFormatter> _function_2 = (IHiddenRegionFormatter it) -> {
           it.newLine();
         };
-        document.<State>append(nestedState, _function_3);
+        document.<State>append(nestedState, _function_2);
       }
     }
   }
@@ -180,8 +171,7 @@ public class StatemachineFormatter extends AbstractFormatter2 {
     Condition _condition = transition.getCondition();
     boolean _tripleNotEquals = (_condition != null);
     if (_tripleNotEquals) {
-      Condition _condition_1 = transition.getCondition();
-      this.format(_condition_1, document);
+      this.format(transition.getCondition(), document);
     }
   }
   

--- a/org.eclipse.xtext.web.servlet/src/main/xtend-gen/org/eclipse/xtext/web/servlet/XtextResourcesServlet.java
+++ b/org.eclipse.xtext.web.servlet/src/main/xtend-gen/org/eclipse/xtext/web/servlet/XtextResourcesServlet.java
@@ -35,8 +35,7 @@ public class XtextResourcesServlet extends HttpServlet {
     super.init(config);
     String disableCache = config.getInitParameter("disableCache");
     if ((disableCache != null)) {
-      boolean _parseBoolean = Boolean.parseBoolean(disableCache);
-      this.disableCache = _parseBoolean;
+      this.disableCache = Boolean.parseBoolean(disableCache);
     }
   }
   

--- a/org.eclipse.xtext.web.servlet/src/main/xtend-gen/org/eclipse/xtext/web/servlet/XtextServlet.java
+++ b/org.eclipse.xtext.web.servlet/src/main/xtend-gen/org/eclipse/xtext/web/servlet/XtextServlet.java
@@ -174,8 +174,7 @@ public class XtextServlet extends HttpServlet {
       Function0<? extends IServiceResult> _service = service.getService();
       final IServiceResult result = _service.apply();
       response.setStatus(HttpServletResponse.SC_OK);
-      String _encoding = this.getEncoding(service, result);
-      response.setCharacterEncoding(_encoding);
+      response.setCharacterEncoding(this.getEncoding(service, result));
       response.setHeader("Cache-Control", "no-cache");
       if (((result instanceof IUnwrappableServiceResult) && (((IUnwrappableServiceResult) result).getContent() != null))) {
         final IUnwrappableServiceResult unwrapResult = ((IUnwrappableServiceResult) result);
@@ -223,8 +222,7 @@ public class XtextServlet extends HttpServlet {
     final String contentType = serviceContext.getParameter("contentType");
     boolean _isNullOrEmpty = StringExtensions.isNullOrEmpty(contentType);
     if (_isNullOrEmpty) {
-      IResourceServiceProvider _resourceServiceProvider = this.serviceProviderRegistry.getResourceServiceProvider(emfURI);
-      resourceServiceProvider = _resourceServiceProvider;
+      resourceServiceProvider = this.serviceProviderRegistry.getResourceServiceProvider(emfURI);
       if ((resourceServiceProvider == null)) {
         String _string = emfURI.toString();
         boolean _isEmpty = _string.isEmpty();
@@ -241,8 +239,7 @@ public class XtextServlet extends HttpServlet {
         }
       }
     } else {
-      IResourceServiceProvider _resourceServiceProvider_1 = this.serviceProviderRegistry.getResourceServiceProvider(emfURI, contentType);
-      resourceServiceProvider = _resourceServiceProvider_1;
+      resourceServiceProvider = this.serviceProviderRegistry.getResourceServiceProvider(emfURI, contentType);
       if ((resourceServiceProvider == null)) {
         StringConcatenation _builder_2 = new StringConcatenation();
         _builder_2.append("Unable to identify the Xtext language for contentType ");

--- a/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/XtextServiceDispatcher.java
+++ b/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/XtextServiceDispatcher.java
@@ -424,8 +424,7 @@ public class XtextServiceDispatcher {
       if ((fullText == null)) {
         throw new InvalidRequestException.ResourceNotFoundException("The requested resource was not found.");
       }
-      XtextWebDocument _fullTextDocument = this.getFullTextDocument(fullText, resourceId, context);
-      document = _fullTextDocument;
+      document = this.getFullTextDocument(fullText, resourceId, context);
     }
     String _parameter = context.getParameter("requiredStateId");
     final XtextWebDocumentAccess documentAccess = this.documentAccessFactory.create(document, _parameter, false);
@@ -785,10 +784,8 @@ public class XtextServiceDispatcher {
     XtextServiceDispatcher.ServiceDescriptor _xblockexpression = null;
     {
       final XtextWebDocumentAccess document = this.getDocumentAccess(context);
-      Optional<Boolean> _of = Optional.<Boolean>of(Boolean.valueOf(false));
-      final boolean allArtifacts = this.getBoolean(context, "allArtifacts", _of);
-      Optional<Boolean> _of_1 = Optional.<Boolean>of(Boolean.valueOf(true));
-      final boolean includeContent = this.getBoolean(context, "includeContent", _of_1);
+      final boolean allArtifacts = this.getBoolean(context, "allArtifacts", Optional.<Boolean>of(Boolean.valueOf(false)));
+      final boolean includeContent = this.getBoolean(context, "includeContent", Optional.<Boolean>of(Boolean.valueOf(true)));
       XtextServiceDispatcher.ServiceDescriptor _serviceDescriptor = new XtextServiceDispatcher.ServiceDescriptor();
       final Procedure1<XtextServiceDispatcher.ServiceDescriptor> _function = (XtextServiceDispatcher.ServiceDescriptor it) -> {
         if (allArtifacts) {
@@ -842,18 +839,13 @@ public class XtextServiceDispatcher {
     Set<String> _parameterKeys = context.getParameterKeys();
     boolean _contains = _parameterKeys.contains("fullText");
     if (_contains) {
-      String _parameter = context.getParameter("fullText");
-      String _resourceID = this.getResourceID(context);
-      XtextWebDocument _fullTextDocument = this.getFullTextDocument(_parameter, _resourceID, context);
-      document = _fullTextDocument;
+      document = this.getFullTextDocument(context.getParameter("fullText"), this.getResourceID(context), context);
       initializedFromFullText = true;
     } else {
       Set<String> _parameterKeys_1 = context.getParameterKeys();
       boolean _contains_1 = _parameterKeys_1.contains("resource");
       if (_contains_1) {
-        String _resourceID_1 = this.getResourceID(context);
-        XtextWebDocument _resourceDocument = this.getResourceDocument(_resourceID_1, context);
-        document = _resourceDocument;
+        document = this.getResourceDocument(this.getResourceID(context), context);
         if ((document == null)) {
           throw new InvalidRequestException.ResourceNotFoundException("The requested resource was not found.");
         }
@@ -861,8 +853,8 @@ public class XtextServiceDispatcher {
         throw new InvalidRequestException.InvalidParametersException("At least one of the parameters \'resource\' and \'fullText\' must be specified.");
       }
     }
-    String _parameter_1 = context.getParameter("requiredStateId");
-    return this.documentAccessFactory.create(document, _parameter_1, initializedFromFullText);
+    String _parameter = context.getParameter("requiredStateId");
+    return this.documentAccessFactory.create(document, _parameter, initializedFromFullText);
   }
   
   /**

--- a/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/contentassist/ContentAssistService.java
+++ b/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/contentassist/ContentAssistService.java
@@ -76,8 +76,7 @@ public class ContentAssistService {
       }
     };
     final ContentAssistContext[] contexts = document.<ContentAssistContext[]>priorityReadOnly(_function);
-    String _get = stateIdWrapper[0];
-    return this.createProposals(((List<ContentAssistContext>)Conversions.doWrapArray(contexts)), _get, proposalsLimit);
+    return this.createProposals(((List<ContentAssistContext>)Conversions.doWrapArray(contexts)), stateIdWrapper[0], proposalsLimit);
   }
   
   /**
@@ -103,8 +102,7 @@ public class ContentAssistService {
       }
     };
     final ContentAssistContext[] contexts = document.<ContentAssistContext[]>modify(_function);
-    String _get = stateIdWrapper[0];
-    return this.createProposals(((List<ContentAssistContext>)Conversions.doWrapArray(contexts)), _get, proposalsLimit);
+    return this.createProposals(((List<ContentAssistContext>)Conversions.doWrapArray(contexts)), stateIdWrapper[0], proposalsLimit);
   }
   
   public ContentAssistContext[] getContexts(final IXtextWebDocument document, final ITextRegion selection, final int caretOffset) {

--- a/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/formatting/FormattingService.java
+++ b/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/formatting/FormattingService.java
@@ -65,9 +65,7 @@ public class FormattingService {
         @Override
         public FormattingResult exec(final IXtextWebDocument it, final CancelIndicator cancelIndicator) throws Exception {
           if ((FormattingService.this.formatter2Provider != null)) {
-            XtextResource _resource = it.getResource();
-            String _format2 = FormattingService.this.format2(_resource, selection, preferences);
-            textWrapper.set(_format2);
+            textWrapper.set(FormattingService.this.format2(it.getResource(), selection, preferences));
             if ((selection != null)) {
               int _offset = selection.getOffset();
               int _length = selection.getLength();
@@ -76,10 +74,8 @@ public class FormattingService {
             }
           } else {
             if ((FormattingService.this.formatter1 != null)) {
-              XtextResource _resource_1 = it.getResource();
-              final INodeModelFormatter.IFormattedRegion formattedRegion = FormattingService.this.format1(_resource_1, selection);
-              String _formattedText = formattedRegion.getFormattedText();
-              textWrapper.set(_formattedText);
+              final INodeModelFormatter.IFormattedRegion formattedRegion = FormattingService.this.format1(it.getResource(), selection);
+              textWrapper.set(formattedRegion.getFormattedText());
               int _offset_1 = formattedRegion.getOffset();
               int _length_1 = formattedRegion.getLength();
               TextRegion _textRegion_1 = new TextRegion(_offset_1, _length_1);
@@ -101,15 +97,9 @@ public class FormattingService {
         public Object exec(final IXtextWebDocument it, final CancelIndicator cancelIndicator) throws Exception {
           boolean _isEmpty = regionWrapper.isEmpty();
           if (_isEmpty) {
-            String _get = textWrapper.get();
-            it.setText(_get);
+            it.setText(textWrapper.get());
           } else {
-            String _get_1 = textWrapper.get();
-            TextRegion _get_2 = regionWrapper.get();
-            int _offset = _get_2.getOffset();
-            TextRegion _get_3 = regionWrapper.get();
-            int _length = _get_3.getLength();
-            it.updateText(_get_1, _offset, _length);
+            it.updateText(textWrapper.get(), regionWrapper.get().getOffset(), regionWrapper.get().getLength());
           }
           return null;
         }

--- a/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/generator/GeneratorService.java
+++ b/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/generator/GeneratorService.java
@@ -166,12 +166,10 @@ public class GeneratorService extends AbstractCachedService<GeneratorService.Gen
     GeneratorResult result = IterableExtensions.<GeneratorResult>findFirst(artifacts, _function);
     if (((result == null) && (!searchString.startsWith(IFileSystemAccess.DEFAULT_OUTPUT)))) {
       final String defaultSearchString = (IFileSystemAccess.DEFAULT_OUTPUT + searchString);
-      final Function1<GeneratorResult, Boolean> _function_1 = (GeneratorResult it) -> {
+      result = IterableExtensions.<GeneratorResult>findFirst(artifacts, ((Function1<GeneratorResult, Boolean>) (GeneratorResult it) -> {
         String _name = it.getName();
         return Boolean.valueOf(Objects.equal(_name, defaultSearchString));
-      };
-      GeneratorResult _findFirst = IterableExtensions.<GeneratorResult>findFirst(artifacts, _function_1);
-      result = _findFirst;
+      }));
     }
     if ((result == null)) {
       throw new InvalidRequestException.ResourceNotFoundException("The requested generator artifact was not found.");

--- a/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/hover/HoverService.java
+++ b/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/hover/HoverService.java
@@ -89,8 +89,7 @@ public class HoverService {
         {
           XtextResource _resource = it.getResource();
           final EObject element = HoverService.this._elementAtOffsetUtil.getElementAt(_resource, offset);
-          String _stateId = it.getStateId();
-          _xblockexpression = HoverService.this.createHover(element, _stateId, cancelIndicator);
+          _xblockexpression = HoverService.this.createHover(element, it.getStateId(), cancelIndicator);
         }
         return _xblockexpression;
       }
@@ -126,9 +125,7 @@ public class HoverService {
               return (_get == null);
             }
           });
-          Object _get = proposedElement.get();
-          String _stateId = it.getStateId();
-          _xblockexpression = HoverService.this.createHover(_get, _stateId, cancelIndicator);
+          _xblockexpression = HoverService.this.createHover(proposedElement.get(), it.getStateId(), cancelIndicator);
         }
         return _xblockexpression;
       }
@@ -169,8 +166,7 @@ public class HoverService {
       if (((eobject != null) && (!eobject.eIsProxy()))) {
         final String documentation = this._iEObjectDocumentationProvider.getDocumentation(eobject);
         if ((documentation != null)) {
-          String _surroundWithDiv_1 = this.surroundWithDiv(documentation, "xtext-hover");
-          bodyHtml = _surroundWithDiv_1;
+          bodyHtml = this.surroundWithDiv(documentation, "xtext-hover");
         }
       }
       return new HoverResult(stateId, titleHtml, bodyHtml);

--- a/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/model/XtextWebDocumentAccess.java
+++ b/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/model/XtextWebDocumentAccess.java
@@ -137,10 +137,8 @@ public class XtextWebDocumentAccess {
   
   @Inject
   protected void setExecutorServiceProvider(final ExecutorServiceProvider executorServiceProvider) {
-    ExecutorService _get = executorServiceProvider.get(XtextWebDocumentAccess.DOCUMENT_LOCK_EXECUTOR);
-    this.executorService1 = _get;
-    ExecutorService _get_1 = executorServiceProvider.get();
-    this.executorService2 = _get_1;
+    this.executorService1 = executorServiceProvider.get(XtextWebDocumentAccess.DOCUMENT_LOCK_EXECUTOR);
+    this.executorService2 = executorServiceProvider.get();
   }
   
   protected void init(final XtextWebDocument document, final String requiredStateId, final boolean skipAsyncWork) {
@@ -209,10 +207,8 @@ public class XtextWebDocumentAccess {
         synchronizer.acquireLock(priority);
         this.checkStateId();
         synchronousWork.setCancelIndicator(synchronizer);
-        T _exec = synchronousWork.exec(documentAccess);
-        result = _exec;
-        String _stateId = this.document.getStateId();
-        this.requiredStateId = _stateId;
+        result = synchronousWork.exec(documentAccess);
+        this.requiredStateId = this.document.getStateId();
         if ((((((!this.skipAsyncWork) && priority) && (documentAccess != null)) && (!synchronizer.isCanceled())) && (!Thread.currentThread().isInterrupted()))) {
           final Procedure1<Object> _function = (Object it) -> {
             try {

--- a/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/syntaxcoloring/HighlightingService.java
+++ b/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/syntaxcoloring/HighlightingService.java
@@ -37,8 +37,7 @@ public class HighlightingService extends AbstractCachedService<HighlightingResul
   @Override
   public HighlightingResult compute(final IXtextWebDocument it, final CancelIndicator cancelIndicator) {
     final HighlightingResult result = new HighlightingResult();
-    List<HighlightingResult.Region> _regions = result.getRegions();
-    final IHighlightedPositionAcceptor acceptor = this.createHighlightedPositionAcceptor(_regions);
+    final IHighlightedPositionAcceptor acceptor = this.createHighlightedPositionAcceptor(result.getRegions());
     XtextResource _resource = it.getResource();
     this.highlightingCalculator.provideHighlightingFor(_resource, acceptor, cancelIndicator);
     return result;

--- a/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/Bug489571Test.java
+++ b/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/Bug489571Test.java
@@ -45,8 +45,7 @@ public class Bug489571Test extends AbstractWebServerTest {
     String _name = file.getName();
     Pair<String, String> _mappedTo_1 = Pair.<String, String>of("resource", _name);
     final XtextServiceDispatcher.ServiceDescriptor format = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1)));
-    boolean _isHasSideEffects = format.isHasSideEffects();
-    Assert.assertTrue(_isHasSideEffects);
+    Assert.assertTrue(format.isHasSideEffects());
     Function0<? extends IServiceResult> _service = format.getService();
     IServiceResult _apply = _service.apply();
     final FormattingResult result = ((FormattingResult) _apply);
@@ -61,8 +60,7 @@ public class Bug489571Test extends AbstractWebServerTest {
     _builder.newLine();
     _builder.append("]");
     final String expectedResult = _builder.toString();
-    String _string = result.toString();
-    Assert.assertEquals(expectedResult, _string);
+    Assert.assertEquals(expectedResult, result.toString());
   }
   
   @Test
@@ -75,8 +73,7 @@ public class Bug489571Test extends AbstractWebServerTest {
     Pair<String, String> _mappedTo_3 = Pair.<String, String>of("resource", _name);
     final XtextServiceDispatcher.ServiceDescriptor format = this.getService(
       Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1, _mappedTo_2, _mappedTo_3)));
-    boolean _isHasSideEffects = format.isHasSideEffects();
-    Assert.assertTrue(_isHasSideEffects);
+    Assert.assertTrue(format.isHasSideEffects());
     Function0<? extends IServiceResult> _service = format.getService();
     IServiceResult _apply = _service.apply();
     final FormattingResult result = ((FormattingResult) _apply);
@@ -94,7 +91,6 @@ public class Bug489571Test extends AbstractWebServerTest {
     _builder.newLine();
     _builder.append("]");
     final String expectedResult = _builder.toString();
-    String _string = result.toString();
-    Assert.assertEquals(expectedResult, _string);
+    Assert.assertEquals(expectedResult, result.toString());
   }
 }

--- a/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/ContentAssistTest.java
+++ b/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/ContentAssistTest.java
@@ -18,7 +18,6 @@ import org.eclipse.xtext.web.server.test.AbstractWebServerTest;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Functions.Function0;
 import org.eclipse.xtext.xbase.lib.Pair;
-import org.hamcrest.Matcher;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Assert;
 import org.junit.Test;
@@ -47,14 +46,11 @@ public class ContentAssistTest extends AbstractWebServerTest {
     Pair<String, String> _mappedTo_2 = Pair.<String, String>of("caretOffset", _string_1);
     final XtextServiceDispatcher.ServiceDescriptor contentAssist = this.getService(
       Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1, _mappedTo_2)));
-    boolean _isHasSideEffects = contentAssist.isHasSideEffects();
-    Assert.assertFalse(_isHasSideEffects);
+    Assert.assertFalse(contentAssist.isHasSideEffects());
     Function0<? extends IServiceResult> _service = contentAssist.getService();
     IServiceResult _apply = _service.apply();
     final ContentAssistResult result = ((ContentAssistResult) _apply);
-    String _string_2 = expectedResult.toString();
-    String _string_3 = result.toString();
-    Assert.assertEquals(_string_2, _string_3);
+    Assert.assertEquals(expectedResult.toString(), result.toString());
   }
   
   @Test
@@ -1166,13 +1162,10 @@ public class ContentAssistTest extends AbstractWebServerTest {
     Pair<String, String> _mappedTo_3 = Pair.<String, String>of("requiredStateId", "totalerquatsch");
     final XtextServiceDispatcher.ServiceDescriptor contentAssist = this.getService(
       Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1, _mappedTo_2, _mappedTo_3)));
-    boolean _isHasConflict = contentAssist.isHasConflict();
-    Assert.assertTrue(_isHasConflict);
+    Assert.assertTrue(contentAssist.isHasConflict());
     Function0<? extends IServiceResult> _service = contentAssist.getService();
     final IServiceResult result = _service.apply();
-    Matcher<IServiceResult> _instanceOf = IsInstanceOf.<IServiceResult>instanceOf(ServiceConflictResult.class);
-    Assert.<IServiceResult>assertThat(result, _instanceOf);
-    String _conflict = ((ServiceConflictResult) result).getConflict();
-    Assert.assertEquals(_conflict, "invalidStateId");
+    Assert.<IServiceResult>assertThat(result, IsInstanceOf.<IServiceResult>instanceOf(ServiceConflictResult.class));
+    Assert.assertEquals(((ServiceConflictResult) result).getConflict(), "invalidStateId");
   }
 }

--- a/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/Formatting1Test.java
+++ b/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/Formatting1Test.java
@@ -49,8 +49,7 @@ public class Formatting1Test extends AbstractWebServerTest {
     String _name = file.getName();
     Pair<String, String> _mappedTo_1 = Pair.<String, String>of("resource", _name);
     final XtextServiceDispatcher.ServiceDescriptor format = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1)));
-    boolean _isHasSideEffects = format.isHasSideEffects();
-    Assert.assertTrue(_isHasSideEffects);
+    Assert.assertTrue(format.isHasSideEffects());
     Function0<? extends IServiceResult> _service = format.getService();
     IServiceResult _apply = _service.apply();
     final FormattingResult result = ((FormattingResult) _apply);
@@ -68,8 +67,7 @@ public class Formatting1Test extends AbstractWebServerTest {
     _builder.newLine();
     _builder.append("]");
     final String expectedResult = _builder.toString();
-    String _string = result.toString();
-    Assert.assertEquals(expectedResult, _string);
+    Assert.assertEquals(expectedResult, result.toString());
   }
   
   @Test
@@ -82,8 +80,7 @@ public class Formatting1Test extends AbstractWebServerTest {
     Pair<String, String> _mappedTo_3 = Pair.<String, String>of("resource", _name);
     final XtextServiceDispatcher.ServiceDescriptor format = this.getService(
       Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1, _mappedTo_2, _mappedTo_3)));
-    boolean _isHasSideEffects = format.isHasSideEffects();
-    Assert.assertTrue(_isHasSideEffects);
+    Assert.assertTrue(format.isHasSideEffects());
     Function0<? extends IServiceResult> _service = format.getService();
     IServiceResult _apply = _service.apply();
     final FormattingResult result = ((FormattingResult) _apply);
@@ -101,7 +98,6 @@ public class Formatting1Test extends AbstractWebServerTest {
     _builder.newLine();
     _builder.append("]");
     final String expectedResult = _builder.toString();
-    String _string = result.toString();
-    Assert.assertEquals(expectedResult, _string);
+    Assert.assertEquals(expectedResult, result.toString());
   }
 }

--- a/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/Formatting2Test.java
+++ b/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/Formatting2Test.java
@@ -29,8 +29,7 @@ public class Formatting2Test extends AbstractWebServerTest {
     String _name = file.getName();
     Pair<String, String> _mappedTo_1 = Pair.<String, String>of("resource", _name);
     final XtextServiceDispatcher.ServiceDescriptor format = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1)));
-    boolean _isHasSideEffects = format.isHasSideEffects();
-    Assert.assertTrue(_isHasSideEffects);
+    Assert.assertTrue(format.isHasSideEffects());
     Function0<? extends IServiceResult> _service = format.getService();
     IServiceResult _apply = _service.apply();
     final FormattingResult result = ((FormattingResult) _apply);
@@ -45,8 +44,7 @@ public class Formatting2Test extends AbstractWebServerTest {
     _builder.newLine();
     _builder.append("]");
     final String expectedResult = _builder.toString();
-    String _string = result.toString();
-    Assert.assertEquals(expectedResult, _string);
+    Assert.assertEquals(expectedResult, result.toString());
   }
   
   @Test
@@ -59,8 +57,7 @@ public class Formatting2Test extends AbstractWebServerTest {
     Pair<String, String> _mappedTo_3 = Pair.<String, String>of("resource", _name);
     final XtextServiceDispatcher.ServiceDescriptor format = this.getService(
       Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1, _mappedTo_2, _mappedTo_3)));
-    boolean _isHasSideEffects = format.isHasSideEffects();
-    Assert.assertTrue(_isHasSideEffects);
+    Assert.assertTrue(format.isHasSideEffects());
     Function0<? extends IServiceResult> _service = format.getService();
     IServiceResult _apply = _service.apply();
     final FormattingResult result = ((FormattingResult) _apply);
@@ -78,7 +75,6 @@ public class Formatting2Test extends AbstractWebServerTest {
     _builder.newLine();
     _builder.append("]");
     final String expectedResult = _builder.toString();
-    String _string = result.toString();
-    Assert.assertEquals(expectedResult, _string);
+    Assert.assertEquals(expectedResult, result.toString());
   }
 }

--- a/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/GeneratorTest.java
+++ b/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/GeneratorTest.java
@@ -90,8 +90,7 @@ public class GeneratorTest extends AbstractWebServerTest {
     String _name = file.getName();
     Pair<String, String> _mappedTo_1 = Pair.<String, String>of("resource", _name);
     final XtextServiceDispatcher.ServiceDescriptor generate = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1)));
-    boolean _isHasSideEffects = generate.isHasSideEffects();
-    Assert.assertFalse(_isHasSideEffects);
+    Assert.assertFalse(generate.isHasSideEffects());
     Function0<? extends IServiceResult> _service = generate.getService();
     IServiceResult _apply = _service.apply();
     final GeneratorResult result = ((GeneratorResult) _apply);
@@ -106,8 +105,7 @@ public class GeneratorTest extends AbstractWebServerTest {
     _builder.newLine();
     _builder.append("]");
     final String expectedResult = _builder.toString();
-    String _string = result.toString();
-    Assert.assertEquals(expectedResult, _string);
+    Assert.assertEquals(expectedResult, result.toString());
   }
   
   @Test
@@ -118,8 +116,7 @@ public class GeneratorTest extends AbstractWebServerTest {
     Pair<String, String> _mappedTo_1 = Pair.<String, String>of("resource", _name);
     Pair<String, String> _mappedTo_2 = Pair.<String, String>of("artifact", "DEFAULT_OUTPUT/test.txt");
     final XtextServiceDispatcher.ServiceDescriptor generate = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1, _mappedTo_2)));
-    boolean _isHasSideEffects = generate.isHasSideEffects();
-    Assert.assertFalse(_isHasSideEffects);
+    Assert.assertFalse(generate.isHasSideEffects());
     Function0<? extends IServiceResult> _service = generate.getService();
     IServiceResult _apply = _service.apply();
     final GeneratorResult result = ((GeneratorResult) _apply);
@@ -137,8 +134,7 @@ public class GeneratorTest extends AbstractWebServerTest {
     _builder.newLine();
     _builder.append("]");
     final String expectedResult = _builder.toString();
-    String _string = result.toString();
-    Assert.assertEquals(expectedResult, _string);
+    Assert.assertEquals(expectedResult, result.toString());
   }
   
   @Test
@@ -182,8 +178,7 @@ public class GeneratorTest extends AbstractWebServerTest {
     _builder.newLine();
     _builder.append("]");
     final String expectedResult = _builder.toString();
-    String _string = result.toString();
-    Assert.assertEquals(expectedResult, _string);
+    Assert.assertEquals(expectedResult, result.toString());
   }
   
   @Test
@@ -235,8 +230,7 @@ public class GeneratorTest extends AbstractWebServerTest {
     _builder.newLine();
     _builder.append("]");
     final String expectedResult = _builder.toString();
-    String _string = result.toString();
-    Assert.assertEquals(expectedResult, _string);
+    Assert.assertEquals(expectedResult, result.toString());
   }
   
   @Test
@@ -283,7 +277,6 @@ public class GeneratorTest extends AbstractWebServerTest {
     _builder.newLine();
     _builder.append("]");
     final String expectedResult = _builder.toString();
-    String _string = result.toString();
-    Assert.assertEquals(expectedResult, _string);
+    Assert.assertEquals(expectedResult, result.toString());
   }
 }

--- a/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/HighlightingTest.java
+++ b/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/HighlightingTest.java
@@ -35,32 +35,24 @@ public class HighlightingTest extends AbstractWebServerTest {
     Function0<? extends IServiceResult> _service = highlighting.getService();
     IServiceResult _apply = _service.apply();
     final HighlightingResult result = ((HighlightingResult) _apply);
-    int _length = styleClasses.length;
-    List<HighlightingResult.Region> _regions = result.getRegions();
-    int _size = _regions.size();
-    Assert.assertEquals(_length, _size);
+    Assert.assertEquals(styleClasses.length, result.getRegions().size());
     int offset = 0;
     final String[] snippets = content.split("#");
     for (int i = 0; (i < styleClasses.length); i++) {
       {
         int _offset = offset;
         String _get = snippets[(2 * i)];
-        int _length_1 = _get.length();
-        offset = (_offset + _length_1);
+        int _length = _get.length();
+        offset = (_offset + _length);
         String _get_1 = snippets[((2 * i) + 1)];
         final int length = _get_1.length();
-        List<HighlightingResult.Region> _regions_1 = result.getRegions();
-        final HighlightingResult.Region region = _regions_1.get(i);
-        Object _get_2 = styleClasses[i];
-        String[] _styleClasses = region.getStyleClasses();
-        Object _head = IterableExtensions.<Object>head(((Iterable<Object>)Conversions.doWrapArray(_styleClasses)));
-        Assert.assertEquals(_get_2, _head);
-        int _offset_1 = region.getOffset();
-        Assert.assertEquals(offset, _offset_1);
-        int _length_2 = region.getLength();
-        Assert.assertEquals(length, _length_2);
-        int _offset_2 = offset;
-        offset = (_offset_2 + length);
+        List<HighlightingResult.Region> _regions = result.getRegions();
+        final HighlightingResult.Region region = _regions.get(i);
+        Assert.assertEquals(styleClasses[i], IterableExtensions.<Object>head(((Iterable<Object>)Conversions.doWrapArray(region.getStyleClasses()))));
+        Assert.assertEquals(offset, region.getOffset());
+        Assert.assertEquals(length, region.getLength());
+        int _offset_1 = offset;
+        offset = (_offset_1 + length);
       }
     }
   }
@@ -68,8 +60,7 @@ public class HighlightingTest extends AbstractWebServerTest {
   protected HoverResult assertTitle(final HoverResult result, final String expectedTitle) {
     HoverResult _xblockexpression = null;
     {
-      String _title = result.getTitle();
-      Assert.assertEquals(expectedTitle, _title);
+      Assert.assertEquals(expectedTitle, result.getTitle());
       _xblockexpression = result;
     }
     return _xblockexpression;
@@ -78,8 +69,7 @@ public class HighlightingTest extends AbstractWebServerTest {
   protected HoverResult assertContent(final HoverResult result, final String expectedContent) {
     HoverResult _xblockexpression = null;
     {
-      String _content = result.getContent();
-      Assert.assertEquals(expectedContent, _content);
+      Assert.assertEquals(expectedContent, result.getContent());
       _xblockexpression = result;
     }
     return _xblockexpression;

--- a/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/HoverTest.java
+++ b/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/HoverTest.java
@@ -63,8 +63,7 @@ public class HoverTest extends AbstractWebServerTest {
   protected HoverResult assertTitle(final HoverResult result, final String expectedTitle) {
     HoverResult _xblockexpression = null;
     {
-      String _title = result.getTitle();
-      Assert.assertEquals(expectedTitle, _title);
+      Assert.assertEquals(expectedTitle, result.getTitle());
       _xblockexpression = result;
     }
     return _xblockexpression;
@@ -73,8 +72,7 @@ public class HoverTest extends AbstractWebServerTest {
   protected HoverResult assertContent(final HoverResult result, final String expectedContent) {
     HoverResult _xblockexpression = null;
     {
-      String _content = result.getContent();
-      Assert.assertEquals(expectedContent, _content);
+      Assert.assertEquals(expectedContent, result.getContent());
       _xblockexpression = result;
     }
     return _xblockexpression;

--- a/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/OccurrenceTest.java
+++ b/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/OccurrenceTest.java
@@ -8,9 +8,7 @@
 package org.eclipse.xtext.web.server.test;
 
 import java.util.Collections;
-import java.util.List;
 import org.eclipse.xtend2.lib.StringConcatenation;
-import org.eclipse.xtext.util.TextRegion;
 import org.eclipse.xtext.web.server.IServiceResult;
 import org.eclipse.xtext.web.server.XtextServiceDispatcher;
 import org.eclipse.xtext.web.server.occurrences.OccurrencesResult;
@@ -43,23 +41,14 @@ public class OccurrenceTest extends AbstractWebServerTest {
   }
   
   protected void assertOccurrences(final CharSequence resourceContent, final CharSequence expectation) {
-    String _string = expectation.toString();
-    String _trim = _string.trim();
-    OccurrencesResult _occurrences = this.getOccurrences(resourceContent);
-    String _string_1 = _occurrences.toString();
-    String _trim_1 = _string_1.trim();
-    Assert.assertEquals(_trim, _trim_1);
+    Assert.assertEquals(expectation.toString().trim(), this.getOccurrences(resourceContent).toString().trim());
   }
   
   @Test
   public void testNoOccurrenceOnEmptyFile() {
     final OccurrencesResult result = this.getOccurrences("#");
-    List<TextRegion> _readRegions = result.getReadRegions();
-    boolean _isEmpty = _readRegions.isEmpty();
-    Assert.assertTrue(_isEmpty);
-    List<TextRegion> _writeRegions = result.getWriteRegions();
-    boolean _isEmpty_1 = _writeRegions.isEmpty();
-    Assert.assertTrue(_isEmpty_1);
+    Assert.assertTrue(result.getReadRegions().isEmpty());
+    Assert.assertTrue(result.getWriteRegions().isEmpty());
   }
   
   @Test
@@ -67,13 +56,10 @@ public class OccurrenceTest extends AbstractWebServerTest {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("#state foo");
     _builder.newLine();
-    final OccurrencesResult result = this.getOccurrences(_builder);
-    List<TextRegion> _readRegions = result.getReadRegions();
-    boolean _isEmpty = _readRegions.isEmpty();
-    Assert.assertTrue(_isEmpty);
-    List<TextRegion> _writeRegions = result.getWriteRegions();
-    boolean _isEmpty_1 = _writeRegions.isEmpty();
-    Assert.assertTrue(_isEmpty_1);
+    OccurrencesResult _occurrences = this.getOccurrences(_builder);
+    final OccurrencesResult result = _occurrences;
+    Assert.assertTrue(result.getReadRegions().isEmpty());
+    Assert.assertTrue(result.getWriteRegions().isEmpty());
   }
   
   @Test

--- a/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/ResourcePersistenceTest.java
+++ b/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/ResourcePersistenceTest.java
@@ -33,15 +33,12 @@ public class ResourcePersistenceTest extends AbstractWebServerTest {
     String _name = file.getName();
     Pair<String, String> _mappedTo_1 = Pair.<String, String>of("resource", _name);
     final XtextServiceDispatcher.ServiceDescriptor load = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1)));
-    boolean _isHasSideEffects = load.isHasSideEffects();
-    Assert.assertFalse(_isHasSideEffects);
+    Assert.assertFalse(load.isHasSideEffects());
     Function0<? extends IServiceResult> _service = load.getService();
     IServiceResult _apply = _service.apply();
     final ResourceContentResult result = ((ResourceContentResult) _apply);
-    String _fullText = result.getFullText();
-    Assert.assertEquals(resourceContent, _fullText);
-    boolean _isDirty = result.isDirty();
-    Assert.assertFalse(_isDirty);
+    Assert.assertEquals(resourceContent, result.getFullText());
+    Assert.assertFalse(result.isDirty());
   }
   
   @Test
@@ -61,27 +58,16 @@ public class ResourcePersistenceTest extends AbstractWebServerTest {
     Function0<? extends IServiceResult> _service_1 = load.getService();
     IServiceResult _apply = _service_1.apply();
     ResourceContentResult result = ((ResourceContentResult) _apply);
-    String _fullText = result.getFullText();
-    Assert.assertEquals(resourceContent, _fullText);
-    Pair<String, String> _mappedTo_5 = Pair.<String, String>of("serviceType", "update");
-    Pair<String, String> _mappedTo_6 = Pair.<String, String>of("resource", "dummy.statemachine");
-    Pair<String, String> _mappedTo_7 = Pair.<String, String>of("deltaText", "bar");
-    Pair<String, String> _mappedTo_8 = Pair.<String, String>of("deltaOffset", "6");
-    Pair<String, String> _mappedTo_9 = Pair.<String, String>of("deltaReplaceLength", "3");
-    XtextServiceDispatcher.ServiceDescriptor _service_2 = this.getService(
-      Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo_5, _mappedTo_6, _mappedTo_7, _mappedTo_8, _mappedTo_9)), session);
-    update = _service_2;
-    Function0<? extends IServiceResult> _service_3 = update.getService();
-    _service_3.apply();
-    Pair<String, String> _mappedTo_10 = Pair.<String, String>of("serviceType", "load");
-    Pair<String, String> _mappedTo_11 = Pair.<String, String>of("resource", "dummy.statemachine");
-    XtextServiceDispatcher.ServiceDescriptor _service_4 = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo_10, _mappedTo_11)), session);
-    load = _service_4;
-    Function0<? extends IServiceResult> _service_5 = load.getService();
-    IServiceResult _apply_1 = _service_5.apply();
+    Assert.assertEquals(resourceContent, result.getFullText());
+    update = this.getService(
+      Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(Pair.<String, String>of("serviceType", "update"), Pair.<String, String>of("resource", "dummy.statemachine"), Pair.<String, String>of("deltaText", "bar"), Pair.<String, String>of("deltaOffset", "6"), Pair.<String, String>of("deltaReplaceLength", "3"))), session);
+    Function0<? extends IServiceResult> _service_2 = update.getService();
+    _service_2.apply();
+    load = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(Pair.<String, String>of("serviceType", "load"), Pair.<String, String>of("resource", "dummy.statemachine"))), session);
+    Function0<? extends IServiceResult> _service_3 = load.getService();
+    IServiceResult _apply_1 = _service_3.apply();
     result = ((ResourceContentResult) _apply_1);
-    String _fullText_1 = result.getFullText();
-    Assert.assertEquals("state bar end", _fullText_1);
+    Assert.assertEquals("state bar end", result.getFullText());
   }
   
   @Test
@@ -109,13 +95,11 @@ public class ResourcePersistenceTest extends AbstractWebServerTest {
     String _name_2 = file.getName();
     Pair<String, String> _mappedTo_8 = Pair.<String, String>of("resource", _name_2);
     final XtextServiceDispatcher.ServiceDescriptor revert = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo_7, _mappedTo_8)), session);
-    boolean _isHasSideEffects = revert.isHasSideEffects();
-    Assert.assertTrue(_isHasSideEffects);
+    Assert.assertTrue(revert.isHasSideEffects());
     Function0<? extends IServiceResult> _service_2 = revert.getService();
     IServiceResult _apply = _service_2.apply();
     final ResourceContentResult result = ((ResourceContentResult) _apply);
-    String _fullText = result.getFullText();
-    Assert.assertEquals(resourceContent, _fullText);
+    Assert.assertEquals(resourceContent, result.getFullText());
   }
   
   @Test
@@ -143,8 +127,7 @@ public class ResourcePersistenceTest extends AbstractWebServerTest {
       String _name_2 = file.getName();
       Pair<String, String> _mappedTo_8 = Pair.<String, String>of("resource", _name_2);
       final XtextServiceDispatcher.ServiceDescriptor save = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo_7, _mappedTo_8)), session);
-      boolean _isHasSideEffects = save.isHasSideEffects();
-      Assert.assertTrue(_isHasSideEffects);
+      Assert.assertTrue(save.isHasSideEffects());
       Function0<? extends IServiceResult> _service_2 = save.getService();
       _service_2.apply();
       final String resourceContent = Files.toString(file, Charsets.UTF_8);

--- a/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/UpdateDocumentTest.java
+++ b/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/UpdateDocumentTest.java
@@ -39,7 +39,6 @@ import org.eclipse.xtext.xbase.lib.Functions.Function0;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.Pair;
 import org.eclipse.xtext.xbase.lib.Pure;
-import org.hamcrest.Matcher;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Assert;
 import org.junit.Test;
@@ -67,8 +66,7 @@ public class UpdateDocumentTest extends AbstractWebServerTest {
       try {
         List<Issue> _xblockexpression = null;
         {
-          Thread _currentThread = Thread.currentThread();
-          this.workerThread = _currentThread;
+          this.workerThread = Thread.currentThread();
           synchronized (this) {
             this.entryCounter++;
             this.notifyAll();
@@ -183,33 +181,22 @@ public class UpdateDocumentTest extends AbstractWebServerTest {
     Pair<String, String> _mappedTo_4 = Pair.<String, String>of("deltaReplaceLength", "3");
     XtextServiceDispatcher.ServiceDescriptor update = this.getService(
       Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1, _mappedTo_2, _mappedTo_3, _mappedTo_4)), session);
-    boolean _isHasSideEffects = update.isHasSideEffects();
-    Assert.assertTrue(_isHasSideEffects);
+    Assert.assertTrue(update.isHasSideEffects());
     Function0<? extends IServiceResult> _service = update.getService();
     IServiceResult _apply = _service.apply();
     final DocumentStateResult updateResult = ((DocumentStateResult) _apply);
-    Pair<String, String> _mappedTo_5 = Pair.<String, String>of("serviceType", "update");
+    update = this.getService(
+      Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(Pair.<String, String>of("serviceType", "update"), Pair.<String, String>of("resource", file.getName()), Pair.<String, String>of("deltaText", " set x = true"), Pair.<String, String>of("deltaOffset", "24"), Pair.<String, String>of("deltaReplaceLength", "0"), Pair.<String, String>of("requiredStateId", updateResult.getStateId()))), session);
+    Function0<? extends IServiceResult> _service_1 = update.getService();
+    _service_1.apply();
+    Pair<String, String> _mappedTo_5 = Pair.<String, String>of("serviceType", "load");
     String _name_1 = file.getName();
     Pair<String, String> _mappedTo_6 = Pair.<String, String>of("resource", _name_1);
-    Pair<String, String> _mappedTo_7 = Pair.<String, String>of("deltaText", " set x = true");
-    Pair<String, String> _mappedTo_8 = Pair.<String, String>of("deltaOffset", "24");
-    Pair<String, String> _mappedTo_9 = Pair.<String, String>of("deltaReplaceLength", "0");
-    String _stateId = updateResult.getStateId();
-    Pair<String, String> _mappedTo_10 = Pair.<String, String>of("requiredStateId", _stateId);
-    XtextServiceDispatcher.ServiceDescriptor _service_1 = this.getService(
-      Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo_5, _mappedTo_6, _mappedTo_7, _mappedTo_8, _mappedTo_9, _mappedTo_10)), session);
-    update = _service_1;
-    Function0<? extends IServiceResult> _service_2 = update.getService();
-    _service_2.apply();
-    Pair<String, String> _mappedTo_11 = Pair.<String, String>of("serviceType", "load");
-    String _name_2 = file.getName();
-    Pair<String, String> _mappedTo_12 = Pair.<String, String>of("resource", _name_2);
-    final XtextServiceDispatcher.ServiceDescriptor load = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo_11, _mappedTo_12)), session);
-    Function0<? extends IServiceResult> _service_3 = load.getService();
-    IServiceResult _apply_1 = _service_3.apply();
+    final XtextServiceDispatcher.ServiceDescriptor load = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo_5, _mappedTo_6)), session);
+    Function0<? extends IServiceResult> _service_2 = load.getService();
+    IServiceResult _apply_1 = _service_2.apply();
     final ResourceContentResult loadResult = ((ResourceContentResult) _apply_1);
-    String _fullText = loadResult.getFullText();
-    Assert.assertEquals("input signal x state bar set x = true end", _fullText);
+    Assert.assertEquals("input signal x state bar set x = true end", loadResult.getFullText());
   }
   
   @Test
@@ -225,14 +212,11 @@ public class UpdateDocumentTest extends AbstractWebServerTest {
     Pair<String, String> _mappedTo_5 = Pair.<String, String>of("requiredStateId", "totalerquatsch");
     final XtextServiceDispatcher.ServiceDescriptor update = this.getService(
       Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1, _mappedTo_2, _mappedTo_3, _mappedTo_4, _mappedTo_5)));
-    boolean _isHasConflict = update.isHasConflict();
-    Assert.assertTrue(_isHasConflict);
+    Assert.assertTrue(update.isHasConflict());
     Function0<? extends IServiceResult> _service = update.getService();
     final IServiceResult result = _service.apply();
-    Matcher<IServiceResult> _instanceOf = IsInstanceOf.<IServiceResult>instanceOf(ServiceConflictResult.class);
-    Assert.<IServiceResult>assertThat(result, _instanceOf);
-    String _conflict = ((ServiceConflictResult) result).getConflict();
-    Assert.assertEquals(_conflict, "invalidStateId");
+    Assert.<IServiceResult>assertThat(result, IsInstanceOf.<IServiceResult>instanceOf(ServiceConflictResult.class));
+    Assert.assertEquals(((ServiceConflictResult) result).getConflict(), "invalidStateId");
   }
   
   @Test
@@ -275,10 +259,8 @@ public class UpdateDocumentTest extends AbstractWebServerTest {
     _service_1.apply();
     Function0<? extends IServiceResult> _service_2 = update3.getService();
     final IServiceResult result = _service_2.apply();
-    Matcher<IServiceResult> _instanceOf = IsInstanceOf.<IServiceResult>instanceOf(ServiceConflictResult.class);
-    Assert.<IServiceResult>assertThat(result, _instanceOf);
-    String _conflict = ((ServiceConflictResult) result).getConflict();
-    Assert.assertEquals(_conflict, "invalidStateId");
+    Assert.<IServiceResult>assertThat(result, IsInstanceOf.<IServiceResult>instanceOf(ServiceConflictResult.class));
+    Assert.assertEquals(((ServiceConflictResult) result).getConflict(), "invalidStateId");
   }
   
   @Test
@@ -294,40 +276,28 @@ public class UpdateDocumentTest extends AbstractWebServerTest {
     Pair<String, String> _mappedTo_4 = Pair.<String, String>of("deltaReplaceLength", "3");
     XtextServiceDispatcher.ServiceDescriptor update = this.getService(
       Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1, _mappedTo_2, _mappedTo_3, _mappedTo_4)), session);
-    boolean _isHasSideEffects = update.isHasSideEffects();
-    Assert.assertTrue(_isHasSideEffects);
+    Assert.assertTrue(update.isHasSideEffects());
     Function0<? extends IServiceResult> _service = update.getService();
     IServiceResult _apply = _service.apply();
     final DocumentStateResult updateResult = ((DocumentStateResult) _apply);
-    Pair<String, String> _mappedTo_5 = Pair.<String, String>of("serviceType", "update");
+    update = this.getService(
+      Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(Pair.<String, String>of("serviceType", "update"), Pair.<String, String>of("resource", file.getName()), Pair.<String, String>of("deltaText", " set x = true"), Pair.<String, String>of("deltaOffset", "24"), Pair.<String, String>of("deltaReplaceLength", "0"), Pair.<String, String>of("requiredStateId", updateResult.getStateId()))), session);
     String _name_1 = file.getName();
-    Pair<String, String> _mappedTo_6 = Pair.<String, String>of("resource", _name_1);
-    Pair<String, String> _mappedTo_7 = Pair.<String, String>of("deltaText", " set x = true");
-    Pair<String, String> _mappedTo_8 = Pair.<String, String>of("deltaOffset", "24");
-    Pair<String, String> _mappedTo_9 = Pair.<String, String>of("deltaReplaceLength", "0");
-    String _stateId = updateResult.getStateId();
-    Pair<String, String> _mappedTo_10 = Pair.<String, String>of("requiredStateId", _stateId);
-    XtextServiceDispatcher.ServiceDescriptor _service_1 = this.getService(
-      Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo_5, _mappedTo_6, _mappedTo_7, _mappedTo_8, _mappedTo_9, _mappedTo_10)), session);
-    update = _service_1;
-    String _name_2 = file.getName();
-    Pair<Class<XtextWebDocument>, String> _mappedTo_11 = Pair.<Class<XtextWebDocument>, String>of(XtextWebDocument.class, _name_2);
-    final XtextWebDocument document = session.<XtextWebDocument>get(_mappedTo_11);
+    Pair<Class<XtextWebDocument>, String> _mappedTo_5 = Pair.<Class<XtextWebDocument>, String>of(XtextWebDocument.class, _name_1);
+    final XtextWebDocument document = session.<XtextWebDocument>get(_mappedTo_5);
     XtextResource _resource = document.getResource();
     _resource.setModificationStamp(1234);
-    Function0<? extends IServiceResult> _service_2 = update.getService();
-    final IServiceResult result = _service_2.apply();
-    Matcher<IServiceResult> _instanceOf = IsInstanceOf.<IServiceResult>instanceOf(ServiceConflictResult.class);
-    Assert.<IServiceResult>assertThat(result, _instanceOf);
-    Pair<String, String> _mappedTo_12 = Pair.<String, String>of("serviceType", "load");
-    String _name_3 = file.getName();
-    Pair<String, String> _mappedTo_13 = Pair.<String, String>of("resource", _name_3);
-    final XtextServiceDispatcher.ServiceDescriptor load = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo_12, _mappedTo_13)), session);
-    Function0<? extends IServiceResult> _service_3 = load.getService();
-    IServiceResult _apply_1 = _service_3.apply();
+    Function0<? extends IServiceResult> _service_1 = update.getService();
+    final IServiceResult result = _service_1.apply();
+    Assert.<IServiceResult>assertThat(result, IsInstanceOf.<IServiceResult>instanceOf(ServiceConflictResult.class));
+    Pair<String, String> _mappedTo_6 = Pair.<String, String>of("serviceType", "load");
+    String _name_2 = file.getName();
+    Pair<String, String> _mappedTo_7 = Pair.<String, String>of("resource", _name_2);
+    final XtextServiceDispatcher.ServiceDescriptor load = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo_6, _mappedTo_7)), session);
+    Function0<? extends IServiceResult> _service_2 = load.getService();
+    IServiceResult _apply_1 = _service_2.apply();
     final ResourceContentResult loadResult = ((ResourceContentResult) _apply_1);
-    String _fullText = loadResult.getFullText();
-    Assert.assertEquals("input signal x state bar end", _fullText);
+    Assert.assertEquals("input signal x state bar end", loadResult.getFullText());
   }
   
   @Test
@@ -532,8 +502,7 @@ public class UpdateDocumentTest extends AbstractWebServerTest {
     Function0<? extends IServiceResult> _service_2 = load.getService();
     IServiceResult _apply_1 = _service_2.apply();
     final ResourceContentResult loadResult = ((ResourceContentResult) _apply_1);
-    String _fullText = loadResult.getFullText();
-    Assert.assertEquals("input signal x state bar set x =  end", _fullText);
+    Assert.assertEquals("input signal x state bar set x =  end", loadResult.getFullText());
   }
   
   @Test

--- a/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/ValidationTest.java
+++ b/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/ValidationTest.java
@@ -18,7 +18,6 @@ import org.eclipse.xtext.web.server.validation.ValidationResult;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Functions.Function0;
 import org.eclipse.xtext.xbase.lib.Pair;
-import org.hamcrest.Matcher;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Assert;
 import org.junit.Test;
@@ -29,13 +28,11 @@ public class ValidationTest extends AbstractWebServerTest {
     Pair<String, String> _mappedTo = Pair.<String, String>of("serviceType", "validate");
     Pair<String, String> _mappedTo_1 = Pair.<String, String>of("fullText", resourceContent);
     final XtextServiceDispatcher.ServiceDescriptor validate = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1)));
-    boolean _isHasSideEffects = validate.isHasSideEffects();
-    Assert.assertFalse(_isHasSideEffects);
+    Assert.assertFalse(validate.isHasSideEffects());
     Function0<? extends IServiceResult> _service = validate.getService();
     IServiceResult _apply = _service.apply();
     final ValidationResult result = ((ValidationResult) _apply);
-    String _string = result.toString();
-    Assert.assertEquals(expectedResult, _string);
+    Assert.assertEquals(expectedResult, result.toString());
   }
   
   @Test
@@ -162,8 +159,7 @@ public class ValidationTest extends AbstractWebServerTest {
     String _name = file.getName();
     Pair<String, String> _mappedTo_1 = Pair.<String, String>of("resource", _name);
     final XtextServiceDispatcher.ServiceDescriptor validate = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1)));
-    boolean _isHasSideEffects = validate.isHasSideEffects();
-    Assert.assertFalse(_isHasSideEffects);
+    Assert.assertFalse(validate.isHasSideEffects());
     Function0<? extends IServiceResult> _service = validate.getService();
     IServiceResult _apply = _service.apply();
     final ValidationResult result = ((ValidationResult) _apply);
@@ -202,8 +198,7 @@ public class ValidationTest extends AbstractWebServerTest {
     _builder.newLine();
     _builder.append("]");
     final String expectedResult = _builder.toString();
-    String _string = result.toString();
-    Assert.assertEquals(expectedResult, _string);
+    Assert.assertEquals(expectedResult, result.toString());
   }
   
   @Test
@@ -215,13 +210,10 @@ public class ValidationTest extends AbstractWebServerTest {
     Pair<String, String> _mappedTo_2 = Pair.<String, String>of("requiredStateId", "totalerquatsch");
     final XtextServiceDispatcher.ServiceDescriptor validate = this.getService(
       Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1, _mappedTo_2)));
-    boolean _isHasConflict = validate.isHasConflict();
-    Assert.assertTrue(_isHasConflict);
+    Assert.assertTrue(validate.isHasConflict());
     Function0<? extends IServiceResult> _service = validate.getService();
     final IServiceResult result = _service.apply();
-    Matcher<IServiceResult> _instanceOf = IsInstanceOf.<IServiceResult>instanceOf(ServiceConflictResult.class);
-    Assert.<IServiceResult>assertThat(result, _instanceOf);
-    String _conflict = ((ServiceConflictResult) result).getConflict();
-    Assert.assertEquals(_conflict, "invalidStateId");
+    Assert.<IServiceResult>assertThat(result, IsInstanceOf.<IServiceResult>instanceOf(ServiceConflictResult.class));
+    Assert.assertEquals(((ServiceConflictResult) result).getConflict(), "invalidStateId");
   }
 }

--- a/org.eclipse.xtext.xbase.web/src/test/xtend-gen/org/eclipse/xtext/xbase/web/test/ContentAssistTest.java
+++ b/org.eclipse.xtext.xbase.web/src/test/xtend-gen/org/eclipse/xtext/xbase/web/test/ContentAssistTest.java
@@ -46,9 +46,7 @@ public class ContentAssistTest extends AbstractXbaseWebTest {
     Function0<? extends IServiceResult> _service = contentAssist.getService();
     IServiceResult _apply = _service.apply();
     final ContentAssistResult result = ((ContentAssistResult) _apply);
-    String _string_2 = expectedResult.toString();
-    String _string_3 = result.toString();
-    Assert.assertEquals(_string_2, _string_3);
+    Assert.assertEquals(expectedResult.toString(), result.toString());
   }
   
   @Test


### PR DESCRIPTION
The Xtend compiler was optimized to minimize the usage of synthetic variables for member feature calls and right-hand assignments

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>