### PR TITLE
Fixed Issue #39 Enabling  CORS when requesting xtext services crossdomain 

### DIFF
--- a/gradle/bootstrap-setup.gradle
+++ b/gradle/bootstrap-setup.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 // The Xtend compiler version to use
-def bootstrapXtendVersion = '2.11.0'
+def bootstrapXtendVersion = '2.12.0.M1'
 
 configurations {
 	xtendCompiler {

--- a/gradle/upstream-repositories.gradle
+++ b/gradle/upstream-repositories.gradle
@@ -23,7 +23,7 @@ def jenkinsPipelineRepo = { jobName -> "http://services.typefox.io/open-source/j
 repositories {
 	jcenter()
 	if (findProperty('useJenkinsSnapshots') == 'true') {
-		maven { url "http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository/" }
+		maven { url "http://services.typefox.io/open-source/jenkins/job/lsp4j/job/release_0.2.0/lastStableBuild/artifact/build/maven-repository/" }
 		maven { url jenkinsPipelineRepo('xtext-lib') }
 		maven { url jenkinsPipelineRepo('xtext-core') }
 		maven { url jenkinsPipelineRepo('xtext-extras') }

--- a/gradle/upstream-repositories.gradle
+++ b/gradle/upstream-repositories.gradle
@@ -23,7 +23,7 @@ def jenkinsPipelineRepo = { jobName -> "http://services.typefox.io/open-source/j
 repositories {
 	jcenter()
 	if (findProperty('useJenkinsSnapshots') == 'true') {
-		maven { url jenkinsPipelineRepo('lsp4j') }
+		maven { url "http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository/" }
 		maven { url jenkinsPipelineRepo('xtext-lib') }
 		maven { url jenkinsPipelineRepo('xtext-core') }
 		maven { url jenkinsPipelineRepo('xtext-extras') }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -2,7 +2,7 @@
  * Base project version and versions of common dependencies.
  */
 
-version = '2.12.0-SNAPSHOT'
+version = '2.12.0'
 
 ext.versions = [
 	'xtext': version,

--- a/org.eclipse.xtext.web/src/main/js/xtext/services/XtextService.js
+++ b/org.eclipse.xtext.web/src/main/js/xtext/services/XtextService.js
@@ -164,7 +164,11 @@ define(['jquery'], function(jQuery) {
 	XtextService.prototype.sendRequest = function(editorContext, settings, needsSession) {
 		var self = this;
 		self.setState('started');
-		
+		var corsEnabled = editorContext._editor.options['enableCors'];
+		if(corsEnabled !== undefined && corsEnabled) {
+			settings.crossDomain = true;
+			settings.xhrFields = {withCredentials: true};
+		} 
 		var onSuccess = settings.success;
 		settings.success = function(result) {
 			var accepted = true;

--- a/org.eclipse.xtext.web/src/main/js/xtext/xtext-codemirror.js
+++ b/org.eclipse.xtext.web/src/main/js/xtext/xtext-codemirror.js
@@ -26,6 +26,8 @@
  *     The document; if not specified, the global document is used.
  * enableContentAssistService = true {Boolean}
  *     Whether content assist should be enabled.
+ * enableCors = true {Boolean}
+ *     Whether CORS should be enabled for service request.
  * enableFormattingAction = false {Boolean}
  *     Whether the formatting action should be bound to the standard keystroke ctrl+shift+s / cmd+shift+f.
  * enableFormattingService = true {Boolean}


### PR DESCRIPTION
When you are using CrossDomain access to request data from the Xtext Services you will receive Error 404 because the xtext resources can not be found. I have added a setting on the client that can be passed into the options for the CreateEditor that will allow the request to the xtext services to enable cors for the request.  On the jetty server I enabled the CORS filter in order to set the correct response headers. 

If it is more desirable I can also modify the XtextServlet.xtend to send back the proper headings. 