### PR TITLE
[eclipse/xtext#1321] bootstrap against 2.16.0.M1

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -6,7 +6,7 @@ version = '2.16.0-SNAPSHOT'
 
 ext.versions = [
 	'xtext': version,
-	'xtext_bootstrap': '2.15.0',
+	'xtext_bootstrap': '2.16.0.M1',
 	'xtext_gradle_plugin': '2.0.1',
 	'emfMwe2': '2.9.1.201705291010',
 	'guice': '3.0',


### PR DESCRIPTION
[eclipse/xtext#1321] bootstrap against 2.16.0.M1
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>