### PR TITLE
[eclipse/xtext#1473] bootstrap against 2.18

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -6,7 +6,7 @@ version = '2.19.0-SNAPSHOT'
 
 ext.versions = [
 	'xtext': version,
-	'xtext_bootstrap': '2.18.0.M2',
+	'xtext_bootstrap': '2.18.0',
 	'xtext_gradle_plugin': '2.0.4',
 	'bnd': '4.2.0',
 	'dependency_management_plugin' : '1.0.7.RELEASE'


### PR DESCRIPTION
[eclipse/xtext#1473] bootstrap against 2.18
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>