### PR TITLE
update to guava 27.1

### DIFF
--- a/gradle/manifest-gen.gradle
+++ b/gradle/manifest-gen.gradle
@@ -14,7 +14,7 @@ def qualifiedVersion = baseVersion + '.v' + buildTime
 
 jar.bnd (
 	'Bundle-Version': qualifiedVersion,
-	'Import-Package': "org.apache.log4j.*;version='1.2.17',com.google.common.*;version='[21.0,22.0)',org.eclipse.core.runtime.*;version=!;common=!,org.eclipse.xtext.xbase.lib.*;version=\"${version}\",!org.eclipse.xtext.web.example.*,!org.eclipse.xtext.idea.example.*,!org.eclipse.xtend2.lib.*,!org.eclipse.xtext.junit4.*,!org.hamcrest.*,!org.junit.*"
+	'Import-Package': "org.apache.log4j.*;version='1.2.17',com.google.common.*;version='[27.1,28.0)',org.eclipse.core.runtime.*;version=!;common=!,org.eclipse.xtext.xbase.lib.*;version=\"${version}\",!org.eclipse.xtext.web.example.*,!org.eclipse.xtext.idea.example.*,!org.eclipse.xtend2.lib.*,!org.eclipse.xtext.junit4.*,!org.hamcrest.*,!org.junit.*"
 )
 
 //------------------------------------------------------


### PR DESCRIPTION
Fixes eclipse/xtext#1398 and eclipse/xtext-lib#111

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>