### PR TITLE
[eclipse/xtext#1526] Replace Jenkinsfile with content of CBI.Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,65 @@
 pipeline {
-  agent any
+  environment {
+    npm_config_cache="/home/jenkins/.npm"
+    NPM_CONFIG_USERCONFIG="/home/jenkins/.config"
+    NO_UPDATE_NOTIFIER="true"
+  }
+  agent {
+    kubernetes {
+      label 'xtext-web-' + env.BRANCH_NAME + '-' + env.BUILD_NUMBER
+      defaultContainer 'xtext-buildenv'
+      yaml '''
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: jnlp
+    image: 'eclipsecbi/jenkins-jnlp-agent'
+    args: ['\$(JENKINS_SECRET)', '\$(JENKINS_NAME)']
+    resources:
+      limits:
+        memory: "0.4Gi"
+        cpu: "0.2"
+      requests:
+        memory: "0.4Gi"
+        cpu: "0.2"
+    volumeMounts:
+    - mountPath: /home/jenkins/.ssh
+      name: volume-known-hosts
+  - name: xtext-buildenv
+    image: docker.io/smoht/xtext-buildenv:0.7
+    tty: true
+    resources:
+      limits:
+        memory: "3.6Gi"
+        cpu: "1.0"
+      requests:
+        memory: "3.6Gi"
+        cpu: "1.0"
+    volumeMounts:
+    - name: settings-xml
+      mountPath: /home/jenkins/.m2/settings.xml
+      subPath: settings.xml
+      readOnly: true
+    - name: m2-repo
+      mountPath: /home/jenkins/.m2/repository
+    - name: volume-known-hosts
+      mountPath: /home/jenkins/.ssh
+  volumes:
+  - name: volume-known-hosts
+    configMap:
+      name: known-hosts
+  - name: settings-xml
+    configMap: 
+      name: m2-dir
+      items:
+      - key: settings.xml
+        path: settings.xml
+  - name: m2-repo
+    emptyDir: {}
+    '''
+    }
+  }
 
   options {
     buildDiscarder(logRotator(numToKeepStr:'5'))
@@ -7,7 +67,8 @@ pipeline {
     timeout(time: 60, unit: 'MINUTES')
     timestamps()
   }
-  
+
+  // Build stages
   stages {
     stage('Checkout') {
       steps {
@@ -29,28 +90,37 @@ pipeline {
     success {
       archiveArtifacts artifacts: 'build/maven-repository/**'
     }
-    changed {
+    cleanup {
       script {
-        def envName = ''
-        if (env.JENKINS_URL.contains('ci.eclipse.org/xtext')) {
-          envName = ' (JIPP)'
-        } else if (env.JENKINS_URL.contains('typefox.io')) {
-          envName = ' (TF)'
-        }
-        
         def curResult = currentBuild.currentResult
-        def color = '#00FF00'
-        if (curResult == 'SUCCESS') {
-           if (currentBuild.previousBuild != null && currentBuild.previousBuild.result != 'SUCCESS') {
-             curResult = 'FIXED'
-           }
-        } else if (curResult == 'UNSTABLE') {
-          color = '#FFFF00'
-        } else { // FAILURE, ABORTED, NOT_BUILD
-          color = '#FF0000'
+        def lastResult = 'NEW'
+        if (currentBuild.previousBuild != null) {
+          lastResult = currentBuild.previousBuild.result
         }
-        
-        slackSend message: "${curResult}: <${env.BUILD_URL}|${env.JOB_NAME}#${env.BUILD_NUMBER}${envName}>", botUser: true, channel: 'xtext-builds', color: "${color}"
+
+        if (curResult != 'SUCCESS' || lastResult != 'SUCCESS') {
+          def color = ''
+          switch (curResult) {
+            case 'SUCCESS':
+              color = '#00FF00'
+              break
+            case 'UNSTABLE':
+              color = '#FFFF00'
+              break
+            case 'FAILURE':
+              color = '#FF0000'
+              break
+            default: // e.g. ABORTED
+              color = '#666666'
+          }
+
+          slackSend (
+            message: "${lastResult} => ${curResult}: <${env.BUILD_URL}|${env.JOB_NAME}#${env.BUILD_NUMBER}>",
+            botUser: true,
+            channel: 'xtext-builds',
+            color: "${color}"
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
This commit purposefully introduces a duplicate Jenkinsfile,
which is meant to be kept long enough for all
branches to receive it.

After this and when the Jenkins jobs point to the new Jenkinsfile,
CBI.Jenkinsfile can be removed without losing build histories in Jenkins

Signed-off-by: Nico Prediger <mail@nicoprediger.de>