### PR TITLE
[eclipse/xtext#1550] set default compliance level to 8.0

### DIFF
--- a/org.eclipse.xtext.web.example.entities/model/generated/Entities.genmodel
+++ b/org.eclipse.xtext.web.example.entities/model/generated/Entities.genmodel
@@ -3,7 +3,7 @@
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" copyrightText="******************************************************************************&#xA;Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.&#xA;All rights reserved. This program and the accompanying materials&#xA;are made available under the terms of the Eclipse Public License v1.0&#xA;which accompanies this distribution, and is available at&#xA;http://www.eclipse.org/legal/epl-v10.html&#xA; ******************************************************************************"
     modelDirectory="/org.eclipse.xtext.web.example.entities/src-gen" modelPluginID="org.eclipse.xtext.web.example.entities"
     forceOverwrite="true" modelName="Entities" updateClasspath="false" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
-    complianceLevel="6.0" copyrightFields="false" runtimeVersion="2.12" usedGenPackages="platform:/resource/org.eclipse.xtext.common.types/model/JavaVMTypes.genmodel#//types platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel#//xbase platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel#//xtype">
+    complianceLevel="8.0" copyrightFields="false" runtimeVersion="2.12" usedGenPackages="platform:/resource/org.eclipse.xtext.common.types/model/JavaVMTypes.genmodel#//types platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel#//xbase platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel#//xtype">
   <genPackages prefix="Domainmodel" basePackage="org.eclipse.xtext.web.example.entities"
       disposableProviderFactory="true" fileExtensions="entities" ecorePackage="Entities.ecore#/">
     <genClasses ecoreClass="Entities.ecore#//Entities">

--- a/org.eclipse.xtext.web.example.statemachine/model/generated/Statemachine.genmodel
+++ b/org.eclipse.xtext.web.example.statemachine/model/generated/Statemachine.genmodel
@@ -3,7 +3,7 @@
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" copyrightText="******************************************************************************&#xA;Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.&#xA;All rights reserved. This program and the accompanying materials&#xA;are made available under the terms of the Eclipse Public License v1.0&#xA;which accompanies this distribution, and is available at&#xA;http://www.eclipse.org/legal/epl-v10.html&#xA; ******************************************************************************"
     modelDirectory="/org.eclipse.xtext.web.example.statemachine/src-gen" modelPluginID="org.eclipse.xtext.web.example.statemachine"
     forceOverwrite="true" modelName="Statemachine" updateClasspath="false" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
-    complianceLevel="6.0" copyrightFields="false" runtimeVersion="2.12">
+    complianceLevel="8.0" copyrightFields="false" runtimeVersion="2.12">
   <genPackages prefix="Statemachine" basePackage="org.eclipse.xtext.web.example.statemachine"
       disposableProviderFactory="true" fileExtensions="statemachine" ecorePackage="Statemachine.ecore#/">
     <genClasses ecoreClass="Statemachine.ecore#//Statemachine">


### PR DESCRIPTION
[eclipse/xtext#1550] set default compliance level to 8.0
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>