### PR TITLE
[#177] Align the Xtext Entities web example to the Domainmodel example.

### DIFF
--- a/org.eclipse.xtext.web.example.entities/src/org/eclipse/xtext/web/example/entities/validation/IssueCodes.java
+++ b/org.eclipse.xtext.web.example.entities/src/org/eclipse/xtext/web/example/entities/validation/IssueCodes.java
@@ -22,4 +22,6 @@ public interface IssueCodes {
 
 	String DUPLICATE_PROPERTY = PREFIX + "DuplicateProperty";
 
+	String DUPLICATE_OPERATION = PREFIX + "DuplicateOperation";
+
 }


### PR DESCRIPTION
- Add checkOperationNamesAreUnique validation rule.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>