### PR TITLE
Align the Xtext Entities web example to the Domainmodel example.

### DIFF
--- a/org.eclipse.xtext.web.example.entities/src/org/eclipse/xtext/web/example/entities/jvmmodel/EntitiesJvmModelHelper.xtend
+++ b/org.eclipse.xtext.web.example.entities/src/org/eclipse/xtext/web/example/entities/jvmmodel/EntitiesJvmModelHelper.xtend
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.web.example.entities.jvmmodel
+
+import com.google.common.collect.HashMultimap
+import com.google.common.collect.Multimap
+import com.google.inject.Inject
+import java.util.Collection
+import java.util.function.Consumer
+import org.eclipse.xtext.common.types.JvmDeclaredType
+import org.eclipse.xtext.common.types.JvmOperation
+import org.eclipse.xtext.xbase.typesystem.^override.OverrideHelper
+
+/**
+ * @author Lorenzo Bettini - Initial contribution and API, https://github.com/eclipse/xtext-eclipse/issues/1205
+ */
+class EntitiesJvmModelHelper {
+
+	@Inject extension OverrideHelper
+
+	/**
+	 * Detects duplicated {@link JvmOperation}s in the passed {@link JvmDeclaredType}
+	 * taking into consideration overloading and type erasure; each collection of
+	 * duplicates is passed to the consumer.
+	 */
+	def void handleDuplicateJvmOperations(JvmDeclaredType jvmDeclaredType,
+		Consumer<Collection<JvmOperation>> consumer) {
+		// takes into consideration overloading and type erasure
+		val methods = jvmDeclaredType.getResolvedFeatures.declaredOperations
+		val Multimap<String, JvmOperation> signature2Declarations = HashMultimap.create
+
+		methods.forEach [
+			signature2Declarations.put(resolvedErasureSignature, declaration)
+		]
+
+		signature2Declarations.asMap.values.forEach [ jvmOperations |
+			if (jvmOperations.size > 1) {
+				consumer.accept(jvmOperations)
+			}
+		]
+	}
+}

--- a/org.eclipse.xtext.web.example.entities/src/org/eclipse/xtext/web/example/entities/jvmmodel/EntitiesJvmModelInferrer.xtend
+++ b/org.eclipse.xtext.web.example.entities/src/org/eclipse/xtext/web/example/entities/jvmmodel/EntitiesJvmModelInferrer.xtend
@@ -8,12 +8,14 @@
 package org.eclipse.xtext.web.example.entities.jvmmodel
 
 import com.google.inject.Inject
+import org.eclipse.xtext.common.types.JvmDeclaredType
 import org.eclipse.xtext.naming.IQualifiedNameProvider
 import org.eclipse.xtext.web.example.entities.domainmodel.Entity
 import org.eclipse.xtext.web.example.entities.domainmodel.Operation
 import org.eclipse.xtext.web.example.entities.domainmodel.Property
 import org.eclipse.xtext.xbase.jvmmodel.AbstractModelInferrer
 import org.eclipse.xtext.xbase.jvmmodel.IJvmDeclaredTypeAcceptor
+import org.eclipse.xtext.xbase.jvmmodel.IJvmModelAssociations
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypesBuilder
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1
 
@@ -21,6 +23,8 @@ class EntitiesJvmModelInferrer extends AbstractModelInferrer {
 
 	@Inject extension JvmTypesBuilder
 	@Inject extension IQualifiedNameProvider
+	@Inject extension EntitiesJvmModelHelper
+	@Inject extension IJvmModelAssociations
 
 	def dispatch infer(Entity entity, extension IJvmDeclaredTypeAcceptor acceptor, boolean prelinkingPhase) {
 		accept(entity.toClass( entity.fullyQualifiedName )) [
@@ -69,9 +73,22 @@ class EntitiesJvmModelInferrer extends AbstractModelInferrer {
 				}
 			}
 
+			// remove created getters/setters in case they
+			// are explicit in the source code
+			removeDuplicateGettersSetters
+
 			// finally we want to have a nice toString methods.
 			members += entity.toToStringMethod(it)
 		]
 	}
 
+	def private removeDuplicateGettersSetters(JvmDeclaredType inferredType) {
+		inferredType.handleDuplicateJvmOperations[jvmOperations|
+			// we only remove getters/setters we created automatically
+			val getterOrSetter = jvmOperations.filter[primarySourceElement instanceof Property].head
+			if (getterOrSetter !== null)
+				inferredType.members.remove(getterOrSetter)
+			// other duplicated methods will be reported by the validator
+		]
+	}
 }


### PR DESCRIPTION
- Improve duplicated operation validation rule to handle also generated
getters and setters. If there's an explicit getter/setter in the source
code, the generated ones are removed in the model inferrer, so they
won't be detected as duplicates by the validator.

See also https://github.com/eclipse/xtext-eclipse/pull/1234

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>