### PR TITLE
[eclipse/xtext#1548] update bnd gradle plugin to 5.0.0 to avoid warnings with gradle 6.x

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -8,5 +8,5 @@ ext.versions = [
 	'xtext': version,
 	'xtext_bootstrap': '2.21.0.M1',
 	'xtext_gradle_plugin': '2.0.8',
-	'bnd': '4.2.0'
+	'bnd': '5.0.0'
 ]


### PR DESCRIPTION
[eclipse/xtext#1548] update bnd gradle plugin to 5.0.0 to avoid warnings with gradle 6.x

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>