### PR TITLE
[eclipse/xtext#1812] Use centos-7 pod template & config. JDK

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,9 +32,13 @@ pipeline {
 
   // Build stages
   stages {
-    stage('Checkout') {
+    stage('Initialize') {
       steps {
         checkout scm
+
+        script {
+          currentBuild.displayName = String.format("#%s(%s)", BUILD_NUMBER, javaVersion(JDK_VERSION))
+        }
       }
     }
 
@@ -85,5 +89,13 @@ pipeline {
         }
       }
     }
+  }
+}
+
+def javaVersion(String version) {
+  if (!version.contains('-jdk')) {
+    return 'jdk15'
+  } else {
+    return version.replaceAll(".*-(jdk\\d+).*", "\$1")
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,9 +93,5 @@ pipeline {
 }
 
 def javaVersion(String version) {
-  if (!version.contains('-jdk')) {
-    return 'jdk15'
-  } else {
-    return version.replaceAll(".*-(jdk\\d+).*", "\$1")
-  }
+  return version.replaceAll(".*-(jdk\\d+).*", "\$1")
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,69 +1,33 @@
 pipeline {
+  agent {
+    kubernetes {
+      label 'centos-7'
+    }
+  }
+
   environment {
     npm_config_cache=".npm"
     NPM_CONFIG_USERCONFIG=".config"
     NO_UPDATE_NOTIFIER="true"
+    GRADLE_USER_HOME = "$WORKSPACE/.gradle" // workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=564559
   }
-  agent {
-    kubernetes {
-      label 'xtext-web-' + (env.BRANCH_NAME.replace('/','_')) + '-' + env.BUILD_NUMBER
-      defaultContainer 'xtext-buildenv'
-      yaml '''
-apiVersion: v1
-kind: Pod
-spec:
-  containers:
-  - name: jnlp
-    args: ['\$(JENKINS_SECRET)', '\$(JENKINS_NAME)']
-    resources:
-      limits:
-        memory: "0.4Gi"
-        cpu: "0.2"
-      requests:
-        memory: "0.4Gi"
-        cpu: "0.2"
-    volumeMounts:
-    - mountPath: /home/jenkins/.ssh
-      name: volume-known-hosts
-  - name: xtext-buildenv
-    image: docker.io/smoht/xtext-buildenv:0.7
-    tty: true
-    resources:
-      limits:
-        memory: "3.6Gi"
-        cpu: "1.0"
-      requests:
-        memory: "3.6Gi"
-        cpu: "1.0"
-    volumeMounts:
-    - name: settings-xml
-      mountPath: /home/jenkins/.m2/settings.xml
-      subPath: settings.xml
-      readOnly: true
-    - name: m2-repo
-      mountPath: /home/jenkins/.m2/repository
-    - name: volume-known-hosts
-      mountPath: /home/jenkins/.ssh
-  volumes:
-  - name: volume-known-hosts
-    configMap:
-      name: known-hosts
-  - name: settings-xml
-    secret:
-      secretName: m2-secret-dir
-      items:
-      - key: settings.xml
-        path: settings.xml
-  - name: m2-repo
-    emptyDir: {}
-    '''
-    }
+
+  parameters {
+    // see https://wiki.eclipse.org/Jenkins#JDK
+    choice(name: 'JDK_VERSION', description: 'Which JDK should be used?', choices: [
+       'adoptopenjdk-hotspot-jdk8-latest', 'adoptopenjdk-hotspot-jdk11-latest', 'adoptopenjdk-hotspot-latest'
+    ])
   }
 
   options {
     buildDiscarder(logRotator(numToKeepStr:'5'))
     disableConcurrentBuilds()
     timeout(time: 90, unit: 'MINUTES')
+  }
+
+  tools {
+     maven "apache-maven-latest"
+     jdk "${params.JDK_VERSION}"
   }
 
   // Build stages

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
       label 'centos-7'
     }
   }
-
+  
   environment {
     npm_config_cache=".npm"
     NPM_CONFIG_USERCONFIG=".config"
@@ -35,9 +35,9 @@ pipeline {
     stage('Initialize') {
       steps {
         checkout scm
-
+        
         script {
-          currentBuild.displayName = String.format("#%s(%s)", BUILD_NUMBER, javaVersion(JDK_VERSION))
+          currentBuild.displayName = String.format("#%s(JDK%s)", BUILD_NUMBER, javaVersion())
         }
       }
     }
@@ -92,6 +92,8 @@ pipeline {
   }
 }
 
-def javaVersion(String version) {
-  return version.replaceAll(".*-(jdk\\d+).*", "\$1")
+/** return the Java version as Integer (8, 11, ...) */
+def javaVersion() {
+  return Integer.parseInt(params.JDK_VERSION.replaceAll(".*-jdk(\\d+).*", "\$1"))
 }
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
   }
 
   tools {
-     maven "apache-maven-latest"
+     maven "apache-maven-3.6.3"
      jdk "${params.JDK_VERSION}"
   }
 


### PR DESCRIPTION
The centos-7 pod template provides a configuration suitable for most
builds. This makes the configuration of the custom container obsolete.

Additionally JDK versions are now selectable by parameter.

Signed-off-by: Karsten Thoms <karsten.thoms@karakun.com>