### PR TITLE
[eclipse/xtext#1916] Upgrade GSON to 2.8.6

### DIFF
--- a/org.eclipse.xtext.web.servlet/build.gradle
+++ b/org.eclipse.xtext.web.servlet/build.gradle
@@ -10,7 +10,7 @@ javadoc.classpath += configurations.providedCompile
 
 dependencies {
 	compile project(':org.eclipse.xtext.web')
-	compile group: 'com.google.code.gson', name: 'gson', version: '2.8.2'
+	compile group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
 	providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
 }
 


### PR DESCRIPTION
Following platform upgrade of GSON from Bug#569966.

Signed-off-by: Karsten Thoms <karsten.thoms@karakun.com>