### PR TITLE
https://github.com/eclipse/xtext/issues/1862 Guava 30.1.0

### DIFF
--- a/gradle/manifest-gen.gradle
+++ b/gradle/manifest-gen.gradle
@@ -14,7 +14,7 @@ def qualifiedVersion = baseVersion + '.v' + buildTime
 
 jar.bnd (
 	'Bundle-Version': qualifiedVersion,
-	'Import-Package': "org.apache.log4j.*;version='1.2.17',com.google.common.*;version='[27.1,28.0)',org.eclipse.core.runtime.*;version=!;common=!,org.eclipse.xtext.xbase.lib.*;version=\"${version}\",!org.eclipse.xtext.web.example.*,!org.eclipse.xtext.idea.example.*,!org.eclipse.xtend2.lib.*,!org.eclipse.xtext.junit4.*,!org.hamcrest.*,!org.junit.*"
+	'Import-Package': "org.apache.log4j.*;version='1.2.17',com.google.common.*;version='[30.1,31.0)',org.eclipse.core.runtime.*;version=!;common=!,org.eclipse.xtext.xbase.lib.*;version=\"${version}\",!org.eclipse.xtext.web.example.*,!org.eclipse.xtext.idea.example.*,!org.eclipse.xtend2.lib.*,!org.eclipse.xtext.junit4.*,!org.hamcrest.*,!org.junit.*"
 )
 
 //------------------------------------------------------


### PR DESCRIPTION
Update Google Guava version from 27.1.0 to 30.1.0

Signed-off-by: miklossy <miklossy@itemis.de>