### PR TITLE
[eclipse/xtext#2019] workaround for grgit transitive jgit dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,13 @@ buildscript {
 	dependencies {
 		classpath "org.xtext:xtext-gradle-plugin:$versions.xtext_gradle_plugin"
 		classpath "biz.aQute.bnd:biz.aQute.bnd.gradle:$versions.bnd"
+		constraints {
+			classpath("org.eclipse.jgit:org.eclipse.jgit") {
+				version {
+					strictly "[5.13, 6.0["
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
[eclipse/xtext#2019] workaround for grgit transitive jgit dependency
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>