### PR TITLE
[eclipse/xtext#2089] Update to Orbit 2022-12 incl new classgraph & gson

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -68,13 +68,13 @@ ASM (9.3)
 
 * License: BSD-3-Clause
 
-classgraph (4.8.138)
+classgraph (4.8.149)
 
 * License: MIT
 * Project: https://github.com/classgraph/classgraph
 * Source: https://github.com/classgraph/classgraph
 
-Google Gson (2.8)
+Google Gson (2.9.x)
 
 * License: Apache License, 2.0
 

--- a/org.eclipse.xtext.web.servlet/build.gradle
+++ b/org.eclipse.xtext.web.servlet/build.gradle
@@ -10,7 +10,7 @@ javadoc.classpath += configurations.providedCompile
 
 dependencies {
 	api project(':org.eclipse.xtext.web')
-	api group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
+	api group: 'com.google.code.gson', name: 'gson', version: '2.9.1'
 	providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
 }
 


### PR DESCRIPTION
[eclipse/xtext#2089] Update to Orbit 2022-12 incl new classgraph & gson